### PR TITLE
1.1.0

### DIFF
--- a/net.krafting.PedantiK.yml
+++ b/net.krafting.PedantiK.yml
@@ -52,6 +52,7 @@ modules:
     build-commands:
       - install -Dm755 PedantiK.py /app/bin/PedantiK.py
       - cp -r utils/ /app/bin/utils/
+      - install -Dm755 languages/French/options.py /app/bin/languages/French/options.py
       - install -Dm 0644 frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.bin  /app/models/frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.bin
       - install -Dm 0644 net.krafting.PedantiK.desktop  /app/share/applications/net.krafting.PedantiK.desktop
       - install -Dm 0644 net.krafting.PedantiK.metainfo.xml  /app/share/metainfo/net.krafting.PedantiK.metainfo.xml
@@ -63,6 +64,6 @@ modules:
 
       - type: git
         url: https://gitlab.com/Krafting/PedantiK
-        tag: '1.0.5'
-        commit: 896533047883b856a4b1b7f1916d93be6cfdf040
+        tag: '1.1.0'
+        commit: 7c8ca2498eb71d58b8662045aeabd5f9ce2c97bb
 


### PR DESCRIPTION
Features:
+ Fix special characters in title not being sized properly
+ Fix special characters being too much spaced in the page content
+ Add more manual word similarities 
+ Fix clicking on word showing the length of the current shown word and not the real word to find.
+ Fix color not changing when clicking a unguessed word with a close word on top
+ Fix color not reflecting the similarity of words when multiple words were guessed on the same word
+ Start of work to support more languages
+ Use grayscale for all close words, to enhance visibility of current guessed word
+ Only save guessed words once, this shouldn't count towards total guesses at the end of the game
+ When loading last save game, only show grayscale text
+ Remove a unused setting
+ Add new page shortcut CTRL + N